### PR TITLE
Fix TypeError

### DIFF
--- a/delegator.py
+++ b/delegator.py
@@ -6,7 +6,7 @@ from pexpect.popen_spawn import PopenSpawn
 import daemon
 
 # Enable Python subprocesses to work with expect functionality.
-os.environ['PYTHONUNBUFFERED'] = 1
+os.environ['PYTHONUNBUFFERED'] = '1'
 
 class Command(object):
     def __init__(self, cmd):


### PR DESCRIPTION
TypeError: putenv() argument 2 must be string, not int