### PR TITLE
Fixing issue with kill() when using block=False

### DIFF
--- a/delegator.py
+++ b/delegator.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import shlex
+import signal
 
 from pexpect.popen_spawn import PopenSpawn
 
@@ -147,7 +148,7 @@ class Command(object):
         self.subprocess.terminate()
 
     def kill(self):
-        self.subprocess.kill()
+        self.subprocess.kill(signal.SIGINT)
 
     def block(self):
         """Blocks until process is complete."""


### PR DESCRIPTION
When using proc=delegator.run(...,block=False), proc.kill() would not work because it proc.kill did not specify a signal to send.  This fixes that.