### PR TITLE
Add support of return_code for pexpect subprocess

### DIFF
--- a/delegator.py
+++ b/delegator.py
@@ -101,6 +101,10 @@ class Command(object):
 
     @property
     def return_code(self):
+        # Support for pexpect's functionality.
+        if self._uses_pexpect:
+            return self.subprocess.exitstatus
+        # Standard subprocess method.
         return self.subprocess.returncode
 
     @property


### PR DESCRIPTION
Originally, accessing `return_code` property of a `Command` object that uses pexpect as subprocess raises `AttributeError`. Fixed it by accessing `PopenSpawn.exitstatus`