### PR TITLE
Added support for custom timeouts when creating a command

### DIFF
--- a/delegator.py
+++ b/delegator.py
@@ -18,7 +18,7 @@ TIMEOUT = 30
     
 class Command(object):
 
-    def __init__(self, cmd, timeout):
+    def __init__(self, cmd, timeout=TIMEOUT):
         super(Command, self).__init__()
         self.cmd = cmd
         self.timeout = timeout
@@ -189,10 +189,13 @@ class Command(object):
         else:
             self.subprocess.wait()
 
-    def pipe(self, command, timeout=TIMEOUT):
+    def pipe(self, command, timeout):
         """Runs the current command and passes its output to the next
         given process.
         """
+        if not timeout:
+            timeout = self.timeout
+        
         if not self.was_run:
             self.run(block=False)
 
@@ -247,7 +250,7 @@ def chain(command, timeout=TIMEOUT):
 
 
 def run(command, block=True, binary=False, timeout=TIMEOUT):
-    c = Command(command, timeout)
+    c = Command(command, timeout=timeout)
     c.run(block=block, binary=binary)
 
     if block:

--- a/delegator.py
+++ b/delegator.py
@@ -16,9 +16,11 @@ except NameError:
 
 
 class Command(object):
-    def __init__(self, cmd):
+
+    def __init__(self, cmd, timeout=30):
         super(Command, self).__init__()
         self.cmd = cmd
+        self.timeout = timeout
         self.subprocess = None
         self.blocking = None
         self.was_run = False
@@ -48,7 +50,8 @@ class Command(object):
     def _default_pexpect_kwargs(self):
         return {
             'env': os.environ.copy(),
-            'encoding': 'utf-8'
+            'encoding': 'utf-8',
+            'timeout': self.timeout
         }
 
     @property
@@ -151,7 +154,8 @@ class Command(object):
         """Waits on the given pattern to appear in std_out"""
 
         if self.blocking:
-            raise RuntimeError('expect can only be used on non-blocking commands.')
+            raise RuntimeError(
+                'expect can only be used on non-blocking commands.')
 
         self.subprocess.expect(pattern=pattern, timeout=timeout)
 
@@ -159,7 +163,8 @@ class Command(object):
         """Sends the given string or signal to std_in."""
 
         if self.blocking:
-            raise RuntimeError('send can only be used on non-blocking commands.')
+            raise RuntimeError(
+                'send can only be used on non-blocking commands.')
 
         if not signal:
             if self._uses_subprocess:
@@ -242,8 +247,8 @@ def chain(command):
     return c
 
 
-def run(command, block=True, binary=False):
-    c = Command(command)
+def run(command, block=True, binary=False, timeout=30):
+    c = Command(command, timeout)
     c.run(block=block, binary=binary)
 
     if block:

--- a/delegator.py
+++ b/delegator.py
@@ -154,8 +154,7 @@ class Command(object):
         """Waits on the given pattern to appear in std_out"""
 
         if self.blocking:
-            raise RuntimeError(
-                'expect can only be used on non-blocking commands.')
+            raise RuntimeError('expect can only be used on non-blocking commands.')
 
         self.subprocess.expect(pattern=pattern, timeout=timeout)
 
@@ -163,8 +162,7 @@ class Command(object):
         """Sends the given string or signal to std_in."""
 
         if self.blocking:
-            raise RuntimeError(
-                'send can only be used on non-blocking commands.')
+            raise RuntimeError('send can only be used on non-blocking commands.')
 
         if not signal:
             if self._uses_subprocess:

--- a/delegator.py
+++ b/delegator.py
@@ -14,10 +14,11 @@ try:
 except NameError:
     STR_TYPES = (str, )
 
-
+TIMEOUT = 30
+    
 class Command(object):
 
-    def __init__(self, cmd, timeout=30):
+    def __init__(self, cmd, timeout):
         super(Command, self).__init__()
         self.cmd = cmd
         self.timeout = timeout
@@ -188,7 +189,7 @@ class Command(object):
         else:
             self.subprocess.wait()
 
-    def pipe(self, command):
+    def pipe(self, command, timeout=TIMEOUT):
         """Runs the current command and passes its output to the next
         given process.
         """
@@ -197,7 +198,7 @@ class Command(object):
 
         data = self.out
 
-        c = Command(command)
+        c = Command(command, timeout)
         c.run(block=False)
         if data:
             c.send(data)
@@ -228,7 +229,7 @@ def _expand_args(command):
     return command
 
 
-def chain(command, timeout=30):
+def chain(command, timeout=TIMEOUT):
     commands = _expand_args(command)
     data = None
 
@@ -245,7 +246,7 @@ def chain(command, timeout=30):
     return c
 
 
-def run(command, block=True, binary=False, timeout=30):
+def run(command, block=True, binary=False, timeout=TIMEOUT):
     c = Command(command, timeout)
     c.run(block=block, binary=binary)
 


### PR DESCRIPTION
If you are not blocking, and using pexpect, you can now add a timeout parameter when creating a command.  If the command takes longer than this to complete, it will fail and throw the appropriate error code.  The default is 30 seconds.