### PR TITLE
Fix delegator.chain in Python 3

### DIFF
--- a/delegator.py
+++ b/delegator.py
@@ -218,7 +218,7 @@ def _expand_args(command):
 
     # Prepare arguments.
     if isinstance(command, STR_TYPES):
-        splitter = shlex.shlex(command.encode('utf-8'))
+        splitter = shlex.shlex(command)
         splitter.whitespace = '|'
         splitter.whitespace_split = True
         command = []


### PR DESCRIPTION
`delegator.chain` results in exception under Python 3 (in 2.7.13 everything is Ok). Consider following code:

```python
# chain_test.py contents
import delegator

cmd = 'git log | grep commit | wc -l'
c = delegator.chain(cmd)
print(c.out)
```
Running it (I've did it under Python 3.5.2 and 3.6.1):

```bash
$ python chain_test.py
Traceback (most recent call last):
  File "chain_test.py", line 4, in <module>
    c = delegator.chain(cmd)
  File "/Users/me/PY_proj/delegator.py/delegator.py", line 240, in chain
    commands = _expand_args(command)
  File "/Users/me/PY_proj/delegator.py/delegator.py", line 228, in _expand_args
    token = splitter.get_token()
  File "/usr/local/var/pyenv/versions/3.5.2/lib/python3.5/shlex.py", line 90, in get_token
    raw = self.read_token()
  File "/usr/local/var/pyenv/versions/3.5.2/lib/python3.5/shlex.py", line 118, in read_token
    nextchar = self.instream.read(1)
AttributeError: 'bytes' object has no attribute 'read'
```