### PR TITLE
Don't read from finished subprocess

### DIFF
--- a/delegator.py
+++ b/delegator.py
@@ -182,9 +182,12 @@ class Command(object):
         """Blocks until process is complete."""
         if self._uses_subprocess:
             # consume stdout and stderr
-            stdout, stderr = self.subprocess.communicate()
-            self.__out = stdout
-            self.__err = stderr
+            try:
+                stdout, stderr = self.subprocess.communicate()
+                self.__out = stdout
+                self.__err = stderr
+            except ValueError:
+                pass  # Don't read from finished subprocesses.
         else:
             self.subprocess.wait()
 


### PR DESCRIPTION
When `block()` is called on a subprocess that's already been closed, it throws an opaque exception in the Python standard library. We should simply return to the user when `block()` is called on a finished process because there is no more work to be done.