### PR TITLE
fix unicode decode error on windows

### DIFF
--- a/delegator.py
+++ b/delegator.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import shlex
 import signal
+import sys
+import locale
 
 from pexpect.popen_spawn import PopenSpawn
 
@@ -46,9 +48,14 @@ class Command(object):
 
     @property
     def _default_pexpect_kwargs(self):
+        encoding = 'utf-8'
+        if sys.platform == 'win32':
+            default_encoding = locale.getdefaultlocale()[1]
+            if default_encoding is not None:
+                encoding = default_encoding
         return {
             'env': os.environ.copy(),
-            'encoding': 'utf-8',
+            'encoding': encoding,
             'timeout': self.timeout
         }
 


### PR DESCRIPTION
This was originally added in the vendored version of delegator.py for pipenv in kennethreitz/pipenv#814. In order to keep things in sync, and since this seems to be a pretty general purpose patch that we'd want upstream, I'm merging it's contents here.