### PR TITLE
Add missing import (errno)

### DIFF
--- a/delegator.py
+++ b/delegator.py
@@ -4,6 +4,7 @@ import shlex
 import signal
 import sys
 import locale
+import errno
 
 from pexpect.popen_spawn import PopenSpawn
 


### PR DESCRIPTION
Fix the NameError caused by `pid_exists` using the currently unimported `errno` standard library module