### PR TITLE
set timeout for block type commands

### DIFF
--- a/delegator.py
+++ b/delegator.py
@@ -243,7 +243,7 @@ class Command(object):
             # consume stdout and stderr
             if self.blocking:
                 try:
-                    stdout, stderr = self.subprocess.communicate()
+                    stdout, stderr = self.subprocess.communicate(timeout=self.timeout)
                     self.__out = stdout
                     self.__err = stderr
                 except ValueError:


### PR DESCRIPTION
set timeout for block-type commands
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


This will allow a timeout to function on the block-type command runs. 